### PR TITLE
Headless support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ env:
     - SOLIDUS_BRANCH=v2.2
 script:
   - bundle exec rake test_app
-  - ( cd ./spec/dummy && bundle exec rake solidus-adyen:factory_girl:lint RAILS_ENV=test )
+- ( cd ./spec/dummy && bundle exec rake solidus-adyen:factory_girl:lint RAILS_ENV=test )
   - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ env:
     - SOLIDUS_BRANCH=v2.2
 script:
   - bundle exec rake test_app
-- ( cd ./spec/dummy && bundle exec rake solidus-adyen:factory_girl:lint RAILS_ENV=test )
+  - ( cd ./spec/dummy && bundle exec rake solidus-adyen:factory_girl:lint RAILS_ENV=test )
   - bundle exec rspec

--- a/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
+++ b/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
@@ -15,17 +15,14 @@ module Spree
 
       # This is the entry point after an Adyen HPP payment is completed
       def confirm
-        # Reload order as it might have changed since previously loading it
-        # from an auth notification coming in at the same time.
-        # This and the notification processing need to have a lock on the order
-        # as they both decide what to do based on whether or not the order is
-        # complete.
-        @order.with_lock do
-          if @order.complete?
-            confirm_order_already_completed
-          else
-            confirm_order_incomplete
-          end
+        success = Spree::Adyen::ConfirmHppPayment
+                      .new(@order, @payment_method, source_params)
+                      .confirm
+
+        if success
+          handle_successful_payment
+        else
+          handle_failed_payment
         end
       end
 
@@ -44,53 +41,6 @@ module Spree
             @payment_method.shared_secret
         )
           raise Spree::Adyen::InvalidSignatureError, 'Signature invalid!'
-        end
-      end
-
-      # If an authorization notification is received before the redirection the
-      # payment is created there. In this case we just need to assign the addition
-      # parameters received about the source.
-      #
-      # We do this because there is a chance that we never get redirected back
-      # so we need to make sure we complete the payment and order.
-      def confirm_order_already_completed
-        if psp_reference
-          payment = @order.payments.find_by!(response_code: psp_reference)
-        else
-          # If no psp_reference is present but the order is complete then the
-          # notification must have completed the order and created the payment.
-          # Therefore select the last Adyen payment.
-          payment = @order.payments.where(
-              source_type: 'Spree::Adyen::HppSource'
-          ).last
-        end
-
-        payment.source.update(source_params)
-
-        handle_successful_payment
-      end
-
-      def confirm_order_incomplete
-        source = Spree::Adyen::HppSource.new(source_params)
-
-        return handle_failed_payment unless source.authorised?
-
-        # payment is created in a 'checkout' state so that the payment method
-        # can attempt to auth it. The payment of course is already auth'd and
-        # adyen hpp's authorize implementation just returns a dummy response.
-        @order.payments.create!(
-            amount: @order.total,
-            payment_method: @payment_method,
-            source: source,
-            response_code: psp_reference,
-            state: "checkout"
-        )
-
-        if complete
-          handle_successful_payment
-        else
-          #TODO void/cancel payment
-          handle_failed_payment
         end
       end
 
@@ -130,19 +80,6 @@ module Spree
 
       def order_number
         params[:merchantReference]
-      end
-
-      def psp_reference
-        params[:pspReference]
-      end
-
-      def auth_result
-        params[:authResult]
-      end
-
-      def complete
-        @order.contents.advance
-        @order.complete
       end
     end
   end

--- a/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
+++ b/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
@@ -16,8 +16,7 @@ module Spree
       # This is the entry point after an Adyen HPP payment is completed
       def confirm
         success = Spree::Adyen::ConfirmHppPayment
-                      .new(@order, @payment_method, source_params)
-                      .confirm
+                      .confirm @order, @payment_method, source_params
 
         if success
           handle_successful_payment
@@ -52,7 +51,6 @@ module Spree
         raise 'Missing method'
       end
 
-      # @param [Spree::Adyen::InvalidSignatureError] error
       def handle_signature_error(error)
         raise 'Missing method'
       end

--- a/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
+++ b/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
@@ -16,7 +16,7 @@ module Spree
       # This is the entry point after an Adyen HPP payment is completed
       def confirm
         success = Spree::Adyen::ConfirmHppPayment
-                      .confirm @order, @payment_method, source_params
+                      .confirm(@order, @payment_method, adyen_permitted_params)
 
         if success
           handle_successful_payment
@@ -36,7 +36,7 @@ module Spree
 
       def check_signature
         unless ::Adyen::HPP::Signature.verify(
-            response_params,
+            adyen_permitted_params,
             @payment_method.shared_secret
         )
           raise Spree::Adyen::InvalidSignatureError, 'Signature invalid!'
@@ -53,14 +53,6 @@ module Spree
 
       def handle_signature_error(error)
         raise 'Missing method'
-      end
-
-      def source_params
-        adyen_permitted_params
-      end
-
-      def response_params
-        adyen_permitted_params
       end
 
       def adyen_permitted_params

--- a/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
+++ b/app/controllers/concerns/spree/adyen/can_confirm_payment.rb
@@ -1,0 +1,149 @@
+module Spree
+  module Adyen
+    module CanConfirmPayment
+      extend ActiveSupport::Concern
+
+      included do
+        before_action :restore_order, only: :confirm
+        before_action :check_signature, only: :confirm
+
+        rescue_from(
+            Spree::Adyen::InvalidSignatureError,
+            with: :handle_signature_error
+        )
+      end
+
+      # This is the entry point after an Adyen HPP payment is completed
+      def confirm
+        # Reload order as it might have changed since previously loading it
+        # from an auth notification coming in at the same time.
+        # This and the notification processing need to have a lock on the order
+        # as they both decide what to do based on whether or not the order is
+        # complete.
+        @order.with_lock do
+          if @order.complete?
+            confirm_order_already_completed
+          else
+            confirm_order_incomplete
+          end
+        end
+      end
+
+      private
+
+      def restore_order
+        payment_method_id = params.fetch(:merchantReturnData).split('|').last
+
+        @payment_method = Spree::PaymentMethod.find(payment_method_id)
+        @order = Spree::Order.find_by!(number: order_number)
+      end
+
+      def check_signature
+        unless ::Adyen::HPP::Signature.verify(
+            response_params,
+            @payment_method.shared_secret
+        )
+          raise Spree::Adyen::InvalidSignatureError, 'Signature invalid!'
+        end
+      end
+
+      # If an authorization notification is received before the redirection the
+      # payment is created there. In this case we just need to assign the addition
+      # parameters received about the source.
+      #
+      # We do this because there is a chance that we never get redirected back
+      # so we need to make sure we complete the payment and order.
+      def confirm_order_already_completed
+        if psp_reference
+          payment = @order.payments.find_by!(response_code: psp_reference)
+        else
+          # If no psp_reference is present but the order is complete then the
+          # notification must have completed the order and created the payment.
+          # Therefore select the last Adyen payment.
+          payment = @order.payments.where(
+              source_type: 'Spree::Adyen::HppSource'
+          ).last
+        end
+
+        payment.source.update(source_params)
+
+        handle_successful_payment
+      end
+
+      def confirm_order_incomplete
+        source = Spree::Adyen::HppSource.new(source_params)
+
+        return handle_failed_payment unless source.authorised?
+
+        # payment is created in a 'checkout' state so that the payment method
+        # can attempt to auth it. The payment of course is already auth'd and
+        # adyen hpp's authorize implementation just returns a dummy response.
+        @order.payments.create!(
+            amount: @order.total,
+            payment_method: @payment_method,
+            source: source,
+            response_code: psp_reference,
+            state: "checkout"
+        )
+
+        if complete
+          handle_successful_payment
+        else
+          #TODO void/cancel payment
+          handle_failed_payment
+        end
+      end
+
+      def handle_successful_payment
+        raise 'Missing method'
+      end
+
+      def handle_failed_payment
+        raise 'Missing method'
+      end
+
+      # @param [Spree::Adyen::InvalidSignatureError] error
+      def handle_signature_error(error)
+        raise 'Missing method'
+      end
+
+      def source_params
+        adyen_permitted_params
+      end
+
+      def response_params
+        adyen_permitted_params
+      end
+
+      def adyen_permitted_params
+        params.permit(
+            :authResult,
+            :merchantReference,
+            :merchantReturnData,
+            :merchantSig,
+            :paymentMethod,
+            :pspReference,
+            :shopperLocale,
+            :skinCode
+        )
+      end
+
+      def order_number
+        params[:merchantReference]
+      end
+
+      def psp_reference
+        params[:pspReference]
+      end
+
+      def auth_result
+        params[:authResult]
+      end
+
+      def complete
+        @order.contents.advance
+        @order.complete
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/spree/adyen/has_hpp_directory.rb
+++ b/app/controllers/concerns/spree/adyen/has_hpp_directory.rb
@@ -1,0 +1,31 @@
+module Spree
+  module Adyen
+    module HasHppDirectory
+      extend ActiveSupport::Concern
+
+      included do
+        load_resource :order, class: 'Spree::Order', id_param: :order_id
+        load_resource(
+            :payment_method,
+            class: 'Spree::PaymentMethod',
+            id_param: :payment_method_id
+        )
+
+        before_action :init_brands, only: :directory
+      end
+
+      def directory
+        raise 'Missing method'
+      end
+
+      private
+
+      def init_brands
+        @brands = Spree::Adyen::HPP.payment_methods_from_directory(
+            @order,
+            @payment_method
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/spree/adyen/hpps_controller.rb
+++ b/app/controllers/spree/adyen/hpps_controller.rb
@@ -1,19 +1,11 @@
 module Spree
   module Adyen
     class HppsController < Spree::AdyenController
-      load_resource :order, class: "Spree::Order", id_param: :order_id
-      load_resource(
-        :payment_method,
-        class: "Spree::PaymentMethod",
-        id_param: :payment_method_id)
+      include Spree::Adyen::HasHppDirectory
 
       layout false
 
       def directory
-        @brands = Spree::Adyen::HPP.payment_methods_from_directory(
-          @order,
-          @payment_method)
-
         respond_to do |format|
           format.html
           format.json { render json: @brands }

--- a/app/controllers/spree/adyen_redirect_controller.rb
+++ b/app/controllers/spree/adyen_redirect_controller.rb
@@ -41,10 +41,9 @@ module Spree
       redirect_to order_path(@order)
     end
 
-    def check_signature
-      unless ::Adyen::HPP::Signature.verify(response_params, @payment_method.shared_secret)
-        raise Spree::Adyen::InvalidSignatureError, 'Signature invalid!'
-      end
+    def handle_signature_error(error)
+      flash.notice = error.message
+      redirect_to checkout_state_path(@order.state)
     end
 
     # We pass the guest token and payment method id in, pipe seperated in the

--- a/app/controllers/spree/api/adyen/hpps_controller.rb
+++ b/app/controllers/spree/api/adyen/hpps_controller.rb
@@ -2,8 +2,12 @@ module Spree
   module Api
     module Adyen
       class HppsController < Spree::Api::BaseController
-        load_resource :order, class: "Spree::Order", id_param: :order_id
-        load_resource :payment_method, class: "Spree::PaymentMethod", id_param: :payment_method_id
+        load_resource :order, class: 'Spree::Order', id_param: :order_id
+        load_resource(
+            :payment_method,
+            class: 'Spree::PaymentMethod',
+            id_param: :payment_method_id
+        )
 
         def directory
           render json: brands
@@ -12,7 +16,10 @@ module Spree
         private
 
         def brands
-          Spree::Adyen::HPP.payment_methods_from_directory @order, @payment_method
+          Spree::Adyen::HPP.payment_methods_from_directory(
+              @order,
+              @payment_method
+          )
         end
       end
     end

--- a/app/controllers/spree/api/adyen/hpps_controller.rb
+++ b/app/controllers/spree/api/adyen/hpps_controller.rb
@@ -6,9 +6,6 @@ module Spree
         load_resource :payment_method, class: "Spree::PaymentMethod", id_param: :payment_method_id
 
         def directory
-          return render :json => {:error => "payment-method-not-found"}.to_json, :status => 404 if @payment_method.nil?
-          return render :json => {:error => "order-not-found"}.to_json, :status => 404 if @order.nil?
-
           render json: brands
         end
 

--- a/app/controllers/spree/api/adyen/hpps_controller.rb
+++ b/app/controllers/spree/api/adyen/hpps_controller.rb
@@ -1,0 +1,23 @@
+module Spree
+  module Api
+    module Adyen
+      class HppsController < Spree::Api::BaseController
+        load_resource :order, class: "Spree::Order", id_param: :order_id
+        load_resource :payment_method, class: "Spree::PaymentMethod", id_param: :payment_method_id
+
+        def directory
+          return render :json => {:error => "payment-method-not-found"}.to_json, :status => 404 if @payment_method.nil?
+          return render :json => {:error => "order-not-found"}.to_json, :status => 404 if @order.nil?
+
+          render json: brands
+        end
+
+        private
+
+        def brands
+          Spree::Adyen::HPP.payment_methods_from_directory @order, @payment_method
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/adyen/hpps_controller.rb
+++ b/app/controllers/spree/api/adyen/hpps_controller.rb
@@ -2,24 +2,10 @@ module Spree
   module Api
     module Adyen
       class HppsController < Spree::Api::BaseController
-        load_resource :order, class: 'Spree::Order', id_param: :order_id
-        load_resource(
-            :payment_method,
-            class: 'Spree::PaymentMethod',
-            id_param: :payment_method_id
-        )
+        include Spree::Adyen::HasHppDirectory
 
         def directory
-          render json: brands
-        end
-
-        private
-
-        def brands
-          Spree::Adyen::HPP.payment_methods_from_directory(
-              @order,
-              @payment_method
-          )
+          render json: @brands
         end
       end
     end

--- a/app/controllers/spree/api/adyen/redirect_controller.rb
+++ b/app/controllers/spree/api/adyen/redirect_controller.rb
@@ -2,103 +2,40 @@ module Spree
   module Api
     module Adyen
       class RedirectController < Spree::Api::BaseController
-        before_action :restore_order, only: :confirm
-        before_action :check_signature, only: :confirm
+        include Spree::Adyen::CanConfirmPayment
 
-        def confirm
-          @order.with_lock do
-            if @order.complete?
-              confirm_order_already_completed
-            else
-              confirm_order_incomplete
-            end
-          end
-        end
-
-        private
-
-        def restore_order
-          guest_token, payment_method_id = params.fetch(:merchantReturnData)
-                                               .split('|')
-
-          @payment_method = Spree::PaymentMethod.find(payment_method_id)
-          @order = Spree::Order.find_by!(guest_token: guest_token)
-        end
-
-        def check_signature
-          unless ::Adyen::HPP::Signature.verify(response_params, @payment_method.shared_secret)
-            raise 'Payment Method not found.'
-          end
-        end
-
-        def confirm_order_already_completed
-          if psp_reference
-            payment = @order.payments.find_by!(response_code: psp_reference)
-          else
-            payment = @order.payments.where(source_type: 'Spree::Adyen::HppSource').last
-          end
-
-          payment.source.update(source_params)
-
-          redirect_to_order
-        end
-
-        def redirect_to_order
-          render json: order_path(@order)
-        end
-
-        def confirm_order_incomplete
-          source = Spree::Adyen::HppSource.new(source_params)
-
-          return handle_failed_redirect unless source.authorised?
-
-          @order.payments.create!(
-              amount: @order.total,
-              payment_method: @payment_method,
-              source: source,
-              response_code: psp_reference,
-              state: "checkout"
+        def handle_successful_payment
+          render(
+              json: {
+                  redirect: order_path(@order)
+              },
+              status: 200
           )
-
-          if complete
-            redirect_to_order
-          else
-            handle_failed_redirect
-          end
         end
 
-        def handle_failed_redirect
-          render json: checkout_state_path(@order.state)
+        def handle_failed_payment
+          render(
+              json: {
+                  errors: [auth_result],
+                  type: 'payment_failed',
+                  redirect: checkout_state_path(@order)
+              },
+              status: 422
+          )
         end
 
-        def source_params
-          adyen_permitted_params
+        # @param [Spree::Adyen::InvalidSignatureError] error
+        def handle_signature_error(error)
+          render(
+              json: {
+                  errors: [error.message],
+                  type: 'invalid_signature',
+                  redirect: checkout_state_path(@order)
+              },
+              status: 422
+          )
         end
 
-        def response_params
-          adyen_permitted_params
-        end
-
-        def adyen_permitted_params
-          params.permit(
-              :authResult,
-              :merchantReference,
-              :merchantReturnData,
-              :merchantSig,
-              :paymentMethod,
-              :pspReference,
-              :shopperLocale,
-              :skinCode)
-        end
-
-        def psp_reference
-          params[:pspReference]
-        end
-
-        def complete
-          @order.contents.advance
-          @order.complete
-        end
       end
     end
   end

--- a/app/controllers/spree/api/adyen/redirect_controller.rb
+++ b/app/controllers/spree/api/adyen/redirect_controller.rb
@@ -24,7 +24,6 @@ module Spree
           )
         end
 
-        # @param [Spree::Adyen::InvalidSignatureError] error
         def handle_signature_error(error)
           render(
               json: {
@@ -34,6 +33,10 @@ module Spree
               },
               status: 422
           )
+        end
+
+        def auth_result
+          params[:authResult]
         end
 
       end

--- a/app/controllers/spree/api/adyen/redirect_controller.rb
+++ b/app/controllers/spree/api/adyen/redirect_controller.rb
@@ -1,0 +1,105 @@
+module Spree
+  module Api
+    module Adyen
+      class RedirectController < Spree::Api::BaseController
+        before_action :restore_order, only: :confirm
+        before_action :check_signature, only: :confirm
+
+        def confirm
+          @order.with_lock do
+            if @order.complete?
+              confirm_order_already_completed
+            else
+              confirm_order_incomplete
+            end
+          end
+        end
+
+        private
+
+        def restore_order
+          guest_token, payment_method_id = params.fetch(:merchantReturnData)
+                                               .split('|')
+
+          @payment_method = Spree::PaymentMethod.find(payment_method_id)
+          @order = Spree::Order.find_by!(guest_token: guest_token)
+        end
+
+        def check_signature
+          unless ::Adyen::HPP::Signature.verify(response_params, @payment_method.shared_secret)
+            raise 'Payment Method not found.'
+          end
+        end
+
+        def confirm_order_already_completed
+          if psp_reference
+            payment = @order.payments.find_by!(response_code: psp_reference)
+          else
+            payment = @order.payments.where(source_type: 'Spree::Adyen::HppSource').last
+          end
+
+          payment.source.update(source_params)
+
+          redirect_to_order
+        end
+
+        def redirect_to_order
+          render json: order_path(@order)
+        end
+
+        def confirm_order_incomplete
+          source = Spree::Adyen::HppSource.new(source_params)
+
+          return handle_failed_redirect unless source.authorised?
+
+          @order.payments.create!(
+              amount: @order.total,
+              payment_method: @payment_method,
+              source: source,
+              response_code: psp_reference,
+              state: "checkout"
+          )
+
+          if complete
+            redirect_to_order
+          else
+            handle_failed_redirect
+          end
+        end
+
+        def handle_failed_redirect
+          render json: checkout_state_path(@order.state)
+        end
+
+        def source_params
+          adyen_permitted_params
+        end
+
+        def response_params
+          adyen_permitted_params
+        end
+
+        def adyen_permitted_params
+          params.permit(
+              :authResult,
+              :merchantReference,
+              :merchantReturnData,
+              :merchantSig,
+              :paymentMethod,
+              :pspReference,
+              :shopperLocale,
+              :skinCode)
+        end
+
+        def psp_reference
+          params[:pspReference]
+        end
+
+        def complete
+          @order.contents.advance
+          @order.complete
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/adyen/confirm_hpp_payment.rb
+++ b/app/models/spree/adyen/confirm_hpp_payment.rb
@@ -43,7 +43,7 @@ module Spree::Adyen
         ).last
       end
 
-      payment.source.update(source_params)
+      payment.source.update(@source_params)
 
       true
     end

--- a/app/models/spree/adyen/confirm_hpp_payment.rb
+++ b/app/models/spree/adyen/confirm_hpp_payment.rb
@@ -2,7 +2,7 @@ module Spree::Adyen
   # Class responsible for processing HPP order confirmations.
   class ConfirmHppPayment
 
-    def confirm(order, payment_method, source_params)
+    def self.confirm(order, payment_method, source_params)
       @order = order
       @payment_method = payment_method
       @source_params = source_params
@@ -29,7 +29,7 @@ module Spree::Adyen
     #
     # We do this because there is a chance that we never get redirected back
     # so we need to make sure we complete the payment and order.
-    def confirm_order_already_completed
+    def self.confirm_order_already_completed
       if @source_params[:pspReference]
         payment = @order
                       .payments
@@ -48,7 +48,7 @@ module Spree::Adyen
       true
     end
 
-    def confirm_order_incomplete
+    def self.confirm_order_incomplete
       source = Spree::Adyen::HppSource.new(@source_params)
 
       return false unless source.authorised?
@@ -67,7 +67,7 @@ module Spree::Adyen
       complete
     end
 
-    def complete
+    def self.complete
       @order.contents.advance
       @order.complete
     end

--- a/app/models/spree/adyen/confirm_hpp_payment.rb
+++ b/app/models/spree/adyen/confirm_hpp_payment.rb
@@ -1,0 +1,77 @@
+module Spree::Adyen
+  # Class responsible for processing HPP order confirmations.
+  class ConfirmHppPayment
+
+    def initialize(order, payment_method, source_params)
+      @order = order
+      @payment_method = payment_method
+      @source_params = source_params
+    end
+
+    def confirm
+      # Reload order as it might have changed since previously loading it
+      # from an auth notification coming in at the same time.
+      # This and the notification processing need to have a lock on the order
+      # as they both decide what to do based on whether or not the order is
+      # complete.
+      @order.with_lock do
+        if @order.complete?
+          confirm_order_already_completed
+        else
+          confirm_order_incomplete
+        end
+      end
+    end
+
+    private
+
+    # If an authorization notification is received before the redirection the
+    # payment is created there. In this case we just need to assign the addition
+    # parameters received about the source.
+    #
+    # We do this because there is a chance that we never get redirected back
+    # so we need to make sure we complete the payment and order.
+    def confirm_order_already_completed
+      if @source_params[:pspReference]
+        payment = @order
+                      .payments
+                      .find_by!(response_code: @source_params[:pspReference])
+      else
+        # If no psp_reference is present but the order is complete then the
+        # notification must have completed the order and created the payment.
+        # Therefore select the last Adyen payment.
+        payment = @order.payments.where(
+            source_type: 'Spree::Adyen::HppSource'
+        ).last
+      end
+
+      payment.source.update(source_params)
+
+      true
+    end
+
+    def confirm_order_incomplete
+      source = Spree::Adyen::HppSource.new(@source_params)
+
+      return false unless source.authorised?
+
+      # payment is created in a 'checkout' state so that the payment method
+      # can attempt to auth it. The payment of course is already auth'd and
+      # adyen hpp's authorize implementation just returns a dummy response.
+      @order.payments.create!(
+          amount: @order.total,
+          payment_method: @payment_method,
+          source: source,
+          response_code: @source_params[:pspReference],
+          state: 'checkout'
+      )
+
+      complete
+    end
+
+    def complete
+      @order.contents.advance
+      @order.complete
+    end
+  end
+end

--- a/app/models/spree/adyen/confirm_hpp_payment.rb
+++ b/app/models/spree/adyen/confirm_hpp_payment.rb
@@ -2,13 +2,11 @@ module Spree::Adyen
   # Class responsible for processing HPP order confirmations.
   class ConfirmHppPayment
 
-    def initialize(order, payment_method, source_params)
+    def confirm(order, payment_method, source_params)
       @order = order
       @payment_method = payment_method
       @source_params = source_params
-    end
 
-    def confirm
       # Reload order as it might have changed since previously loading it
       # from an auth notification coming in at the same time.
       # This and the notification processing need to have a lock on the order

--- a/config/initializers/solidus_adyen.rb
+++ b/config/initializers/solidus_adyen.rb
@@ -10,3 +10,9 @@ Rails.application.config.assets.precompile += %w(
 Spree::Adyen::HPP.configure do |config|
   config.params_class = Spree::Adyen::HPP::Params
 end
+
+module Spree
+  module Adyen
+    InvalidSignatureError = Class.new(StandardError)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,9 @@
+class AdyenHppDirectoryConstraint
+  def matches?(request)
+    request.params[:payment_method_id].present? && request.params[:order_id].present?
+  end
+end
+
 Spree::Core::Engine.routes.draw do
   namespace :adyen do
     resource :hpp, only: [] do
@@ -13,7 +19,7 @@ Spree::Core::Engine.routes.draw do
 
   namespace :api, defaults: {format: 'json'} do
     namespace :adyen do
-      get 'hpp/directory', to: 'hpps#directory'
+      get 'hpp/directory', to: 'hpps#directory', constraints: AdyenHppDirectoryConstraint.new
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,13 @@ Spree::Core::Engine.routes.draw do
     end
   end
 
-  get "checkout/payment/adyen", to: "adyen_redirect#confirm", as: :adyen_confirmation
-  post "adyen/notify", to: "adyen_notifications#notify"
-  post "adyen/authorise3d", to: "adyen_redirect#authorise3d", as: :adyen_authorise3d
+  get 'checkout/payment/adyen', to: 'adyen_redirect#confirm', as: :adyen_confirmation
+  post 'adyen/notify', to: 'adyen_notifications#notify'
+  post 'adyen/authorise3d', to: 'adyen_redirect#authorise3d', as: :adyen_authorise3d
+
+  namespace :api, defaults: {format: 'json'} do
+    namespace :adyen do
+      get 'hpp/directory', to: 'hpps#directory'
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Spree::Core::Engine.routes.draw do
   namespace :api, defaults: {format: 'json'} do
     namespace :adyen do
       get 'hpp/directory', to: 'hpps#directory', constraints: AdyenHppDirectoryConstraint.new
+      get 'payment/confirm', to: 'redirect#confirm', as: :api_adyen_confirmation
     end
   end
 end

--- a/lib/spree/adyen/hpp/params.rb
+++ b/lib/spree/adyen/hpp/params.rb
@@ -52,7 +52,7 @@ module Spree
         def order_params
           { currency_code: @order.currency,
             merchant_reference: @order.number.to_s,
-            country_code: @order.billing_address.country.iso,
+            country_code: (@order.billing_address.country.iso || ''),
             payment_amount: (@order.total * 100).to_int,
             shopper_locale: I18n.locale.to_s.gsub("-", "_"),
             shopper_email: @order.email,
@@ -87,8 +87,8 @@ module Spree
 
         def address_params
           {
-            delivery_address: address_fields,
-            billing_address: address_fields,
+            delivery_address: (address_fields || ''),
+            billing_address: (address_fields || ''),
           }
         end
 


### PR DESCRIPTION
Add support for headless e-commerce by adding API controllers that mimic current controller functionality.